### PR TITLE
Add Plant Analyzer item

### DIFF
--- a/Content.Server/Botany/Components/PlantAnalyzerComponent.cs
+++ b/Content.Server/Botany/Components/PlantAnalyzerComponent.cs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Robust.Shared.Audio;
+
+namespace Content.Server.Botany.Components;
+
+/// <summary>
+/// Temporary plant analyzer component.
+/// </summary>
+[RegisterComponent]
+public sealed partial class PlantAnalyzerComponent : Component
+{
+    [DataField("scanDelay")]
+    public float ScanDelay = 1f;
+
+    [DataField("scanSound")] 
+    public SoundSpecifier? ScanSound = new SoundPathSpecifier("/Audio/Items/Medical/healthscanner.ogg");
+}

--- a/Content.Server/Botany/Systems/PlantAnalyzerSystem.cs
+++ b/Content.Server/Botany/Systems/PlantAnalyzerSystem.cs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Server.Popups;
+using Content.Server.Botany.Components;
+using Content.Shared.Interaction;
+using Content.Shared.DoAfter;
+using Content.Shared.Interaction.Events;
+using Content.Shared.PlantAnalyzer;
+using Robust.Shared.Audio.Systems;
+
+namespace Content.Server.Botany.Systems;
+
+public sealed class PlantAnalyzerSystem : EntitySystem
+{
+    [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
+    [Dependency] private readonly PopupSystem _popup = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<PlantAnalyzerComponent, AfterInteractEvent>(OnAfterInteract);
+        SubscribeLocalEvent<PlantAnalyzerComponent, PlantAnalyzerDoAfterEvent>(OnDoAfter);
+    }
+
+    private void OnAfterInteract(EntityUid uid, PlantAnalyzerComponent component, ref AfterInteractEvent args)
+    {
+        if (args.Target == null || !args.CanReach)
+            return;
+
+        var doAfter = new DoAfterArgs(EntityManager, args.User, component.ScanDelay, new PlantAnalyzerDoAfterEvent(), uid, target: args.Target, used: uid)
+        {
+            BreakOnMove = true,
+            NeedHand = true,
+            Broadcast = true
+        };
+
+        _doAfter.TryStartDoAfter(doAfter);
+    }
+
+    private void OnDoAfter(EntityUid uid, PlantAnalyzerComponent component, DoAfterEvent args)
+    {
+        if (args.Cancelled || args.Handled)
+            return;
+
+        if (component.ScanSound != null)
+            _audio.PlayPvs(component.ScanSound, uid);
+
+        _popup.PopupEntity(Loc.GetString("plant-analyzer-malfunction"), args.Args.User, args.Args.User);
+        args.Handled = true;
+    }
+}

--- a/Content.Shared/PlantAnalyzer/PlantAnalyzerDoAfterEvent.cs
+++ b/Content.Shared/PlantAnalyzer/PlantAnalyzerDoAfterEvent.cs
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+
+using Content.Shared.DoAfter;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.PlantAnalyzer;
+
+[Serializable, NetSerializable]
+public sealed partial class PlantAnalyzerDoAfterEvent : SimpleDoAfterEvent
+{
+}

--- a/Resources/Locale/en-US/botany/plant_analyzer.ftl
+++ b/Resources/Locale/en-US/botany/plant_analyzer.ftl
@@ -1,0 +1,1 @@
+plant-analyzer-malfunction = The analyzer emits sparks and displays no data.

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/plant_analyzer.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/plant_analyzer.yml
@@ -1,0 +1,13 @@
+- type: entity
+  name: plant analyzer
+  parent: BaseItem
+  id: PlantAnalyzer
+  description: A device used to scan plants. It seems to malfunction.
+  components:
+  - type: Sprite
+    sprite: Objects/Specific/Medical/healthanalyzer.rsi
+    state: icon
+  - type: Item
+    heldPrefix: analyzer
+    storedRotation: -90
+  - type: PlantAnalyzer

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/plant_analyzer.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/plant_analyzer.yml
@@ -1,13 +1,51 @@
+# SPDX-FileCopyrightText: 2025 Codex <codex@openai.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: entity
-  name: plant analyzer
+  id: PlantAnalyzerUnpowered
   parent: BaseItem
-  id: PlantAnalyzer
+  name: plant analyzer
   description: A device used to scan plants. It seems to malfunction.
   components:
   - type: Sprite
     sprite: Objects/Specific/Medical/healthanalyzer.rsi
     state: icon
+    layers:
+      - state: icon
+      - state: analyzer
+        shader: unshaded
+        visible: true
+        map: [ "enum.PowerDeviceVisualLayers.Powered" ]
   - type: Item
     heldPrefix: analyzer
     storedRotation: -90
   - type: PlantAnalyzer
+  - type: Appearance
+  - type: GenericVisualizer
+    visuals:
+      enum.PowerCellSlotVisuals.Enabled:
+        enum.PowerDeviceVisualLayers.Powered:
+          True: { visible: true }
+          False: { visible: false }
+
+- type: entity
+  id: PlantAnalyzer
+  parent: [ PlantAnalyzerUnpowered, PowerCellSlotSmallItem ]
+  suffix: Powered
+  components:
+  - type: PowerCellDraw
+    drawRate: 1.2
+  - type: ToggleCellDraw
+  - type: ActivatableUIRequiresPowerCell
+
+- type: entity
+  id: PlantAnalyzerEmpty
+  parent: PlantAnalyzer
+  suffix: Empty
+  components:
+  - type: ItemSlots
+    slots:
+      cell_slot:
+        name: power-cell-slot-component-slot-name-default
+


### PR DESCRIPTION
## Summary
- add plant analyzer item prototype and localization
- implement PlantAnalyzerComponent and system for basic malfunction popup
- add do-after event for the analyzer

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_6855c1cb65e8832eb90b54799241dc9f